### PR TITLE
feat: adding/fixing functions to read teams and users from console

### DIFF
--- a/cmd/salsasync/main.go
+++ b/cmd/salsasync/main.go
@@ -36,11 +36,14 @@ func main() {
 	defer cancel()
 
 	s := storage.New(cfg.StorageApi, cfg.StorageApiKey)
-	consoleApi := console.NewConfig("apikey")
+	consoleApi := console.NewConfig("key1")
 	teams, err := consoleApi.GetTeams(ctx)
+	users, err := consoleApi.GetUsers(ctx)
 	if err != nil {
-		log.WithError(err).Fatal("failed to get teams")
+		log.WithError(err).Fatal("failed to get users")
 	}
+	log.Debugf("Teams read %+v", teams)
+	log.Debugf("Users read %+v", users)
 
 	if err = s.SynchronizeTeamsAndUsers(teams); err != nil {
 		log.WithError(err).Fatal("failed to synchronize teams and users")

--- a/docker-compose.console.yml
+++ b/docker-compose.console.yml
@@ -42,7 +42,7 @@ services:
           {
             "name": "nais-1",
             "apiKey": "key1",
-            "roles": ["Team viewer", "User viewer", "Team creator"]
+            "roles": ["Team viewer", "User viewer", "Team creator", "Team member", "Admin"]
           }
         ]
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,7 @@ type Config struct {
 func DefaultConfig() *Config {
 	return &Config{
 		MetricsBindAddress: "127.0.0.1:8080",
-		LogLevel:           "info",
+		LogLevel:           "debug",
 		StorageApi:         "http://localhost:9001/api/v1/",
 		StorageApiKey:      "todo",
 		ConsoleApiKey:      "key1",


### PR DESCRIPTION
For å kunne teste les av teams og medlemmer av teams lokalt, må de legges til i console. Det kan gjøres via graphQL:

mutation createTeam {
  createTeam(input: {
    slug: "salsa"
    purpose: "beskrivelse"
    slackChannel:"#slackkanal"
  }) {
    slug
  }
}

mutation addTeamMembers {
  addTeamMembers(
    slug: salsa
    userIds: [
      "392fc437-ad54-4da7-9229-d4b64890c8d3",
    	"037e2681-12a8-4a1e-ad66-0b4d2a23eb8a",
    	"c0658be3-b6ab-41a9-bac2-262f84b4d28f"
    ]
) {
    slug
  }
}